### PR TITLE
Bugfix/build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,10 @@ name: Build and Deploy
 
 on:
   push:
+    branches:
+      - "**"
     tags:
-        - '*'
+      - "*"
   release:
     types: [published]
 
@@ -11,12 +13,42 @@ permissions:
   contents: write
 
 jobs:
+  test:
+    name: Test on Python ${{ matrix.python-version }}
+    if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[dev]
+
+      - name: Run tests
+        run: pytest -v tests/
+
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-latest]
+        os:
+          [
+            ubuntu-latest,
+            ubuntu-24.04-arm,
+            windows-latest,
+            macos-13,
+            macos-latest,
+          ]
 
     steps:
       - uses: actions/checkout@v4
@@ -27,8 +59,8 @@ jobs:
         uses: pypa/cibuildwheel@v3.1.4
         with: { output-dir: wheelhouse }
         env:
+          CIBW_BUILD: "cp312-* cp313-* cp314-*"
           CIBW_SKIP: "*-win32"
-          CIBW_BEFORE_BUILD: "python -m pip install --upgrade pip setuptools wheel"
           CIBW_TEST_REQUIRES: "pytest"
           CIBW_TEST_COMMAND: "pytest -v {project}/tests"
 
@@ -40,11 +72,13 @@ jobs:
 
   make_sdist:
     name: Make SDist
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with: { python-version: "3.12" }
+
       - name: Build sdist
         run: |
           python -m pip install --upgrade pip build
@@ -60,8 +94,7 @@ jobs:
     name: Collect and Deploy
     needs: [build_wheels, make_sdist]
     runs-on: ubuntu-latest
-    # Only run this job for releases
-    if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+    if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - name: Download release artifacts (wheels + sdist)
         uses: actions/download-artifact@v4

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include src/spmat/*.pyx

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Special Matrices (spmat)
 
 [![PyPI](https://img.shields.io/pypi/v/spmat?color=purple)](https://pypi.org/project/spmat/)
-![Python](https://img.shields.io/badge/python-3.10,_3.11,_3.12,_3.13-purple.svg)
-[![Build](https://img.shields.io/github/actions/workflow/status/ihmeuw-msca/spmat/build.yml?branch=refactor/doc-cleanup&label=Build&color=purple)](https://github.com/ihmeuw-msca/spmat/actions)
+![Python](https://img.shields.io/badge/python-3.12,_3.13,_3.14-purple.svg)
+[![Build](https://img.shields.io/github/actions/workflow/status/ihmeuw-msca/spmat/build.yml?branch=main&label=Build&color=purple)](https://github.com/ihmeuw-msca/spmat/actions)
 [![PyPI Downloads](https://static.pepy.tech/personalized-badge/spmat?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=MAGENTA&left_text=Downloads)](https://pepy.tech/projects/spmat)
 
 A collection of tools for special matrices with optimized implementations for scientific computing.
@@ -35,7 +35,7 @@ pip install -e .
 
 ## Requirements
 
-- Python >= 3.10, < 3.14
+- Python >= 3.12
 - NumPy
 - SciPy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [build-system]
-requires = ["setuptools", "Cython>3.0", "numpy", "scipy"]
+requires = ["setuptools", "Cython>=3.2", "numpy", "scipy"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "spmat"
-version = "0.1.1"
+version = "0.1.2"
 description = "spmat: A collection of tools for special matrices"
-readme = "README.md" 
-requires-python = ">=3.10,<3.14"
+readme = "README.md"
+requires-python = ">=3.12"
 license = "BSD-2-Clause"
 
 authors = [
@@ -19,10 +19,9 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering :: Mathematics",
 ]
 
@@ -34,9 +33,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev  = ["pytest"]
+dev = ["pytest"]
 
 [project.urls]
-Homepage     = "https://github.com/ihmeuw-msca/spmat"
-Repository   = "https://github.com/ihmeuw-msca/spmat"
+Homepage = "https://github.com/ihmeuw-msca/spmat"
+Repository = "https://github.com/ihmeuw-msca/spmat"
 Documentation = "https://github.com/ihmeuw-msca/spmat"

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,7 @@ import numpy
 from Cython.Build import cythonize
 from setuptools import setup
 
-if __name__ == "__main__":
-    setup(
-        ext_modules=cythonize("src/spmat/linalg.pyx"),
-        include_dirs=[numpy.get_include()],
-    )
+setup(
+    ext_modules=cythonize("src/spmat/linalg.pyx"),
+    include_dirs=[numpy.get_include()],
+)

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 import numpy
-from Cython.Build import cythonize
-from setuptools import setup
+from setuptools import Extension, setup
 
 setup(
-    ext_modules=cythonize("src/spmat/linalg.pyx"),
+    ext_modules=[Extension("spmat.linalg", ["src/spmat/linalg.pyx"])],
     include_dirs=[numpy.get_include()],
 )


### PR DESCRIPTION
## Summary

- Fix Python 3.13/3.14 build failure caused by outdated Cython generating incompatible C code for `_PyLong_AsByteArray`
- Add CI test job, update supported Python versions to 3.12–3.14, bump to v0.1.2

## What Changed

**New files**
- None

**Modified files**
- `pyproject.toml` — pin `Cython>=3.2`, bump version to `0.1.2`, set `requires-python = ">=3.12"`, add Python 3.14 classifier, drop 3.10/3.11, fix formatting
- `.github/workflows/build.yml` — add `test` job on all branch pushes (Python 3.12/3.13/3.14), add `CIBW_BUILD` to target only supported versions, remove redundant `CIBW_BEFORE_BUILD`, gate `build_wheels`/`make_sdist` on tag pushes only
- `README.md` — update Python version badge, fix build badge branch to `main`, update requirements section
- `setup.py` — replace `cythonize()` with `setuptools.Extension`, remove `if __name__ == "__main__"` guard

**Deleted files**
- `MANIFEST.in` — redundant; `setup.py` registers the `.pyx` file with setuptools via `Extension`, which ensures it's included in the sdist